### PR TITLE
Fix coordinates for Pillow>9.4.0

### DIFF
--- a/ocrmac/ocrmac.py
+++ b/ocrmac/ocrmac.py
@@ -39,10 +39,10 @@ def convert_coordinates_pil(bbox, im_width, im_height):
     """Convert vision coordinates to PIL coordinates"""
     x, y, w, h = bbox
     x1 = x * im_width
-    y1 = (1 - y) * im_height
+    y2 = (1 - y) * im_height
 
     x2 = x1 + w * im_width
-    y2 = y1 - h * im_height
+    y1 = y2 - h * im_height
 
     return x1, y1, x2, y2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyobjc-framework-Vision
-pillow<=9.4.0
+pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyobjc-framework-Vision
-pillow
+pillow<=9.4.0


### PR DESCRIPTION
As of Pillow 9.5.0, it is required that x1 >=x- and y1>=y0. See [this PR](https://github.com/python-pillow/Pillow/pull/6978) for discussion. [Pillow docs](https://pillow.readthedocs.io/en/stable/reference/ImageDraw.html#PIL.ImageDraw.ImageDraw.rectangle) state that for ImageDraw.rectangle, xy is a

> Sequence of either [(x0, y0), (x1, y1)] or [x0, y0, x1, y1], where x1 >= x0 and y1 >= y0. The bounding box is inclusive of both endpoints.

Simply switching the order of y1 and y2 fixes the following error for all subsequent versions of Pillow:

> ValueError: y1 must be greater than or equal to y0