### PR TITLE
correct usage of `livetext_from_image` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ annotations = ocrmac.OCR('test.png', framework="livetext").recognize()
 print(annotations)
 
 # Or use the helper directly
-annotations = ocrmac.livetext_from_image('test.png').recognize()
+annotations = ocrmac.livetext_from_image('test.png')
 ```
 Notice, when using this feature, the `recognition_level` and `confidence_threshold` are not available. The `confidence` output will always be 1.
 


### PR DESCRIPTION
`livetext_from_image` returns annotations directly, without the need to call `recognize` on it